### PR TITLE
Fix multiline parameter functions

### DIFF
--- a/SwiftMacros/Implementation/RaycastMacro.swift
+++ b/SwiftMacros/Implementation/RaycastMacro.swift
@@ -35,19 +35,17 @@ public struct RaycastMacro: PeerMacro {
 
           // Declare all the local variables holding the values decoded from the Command-line arguments
           for param in parameters {
-            let paramName = (param.secondName ?? param.firstName).text.trimmingCharacters(in: .whitespacesAndNewlines)
-            "let \(raw: paramName): \(param.type)"
+            "let \(raw: param.secondName?.text ?? param.firstName.text): \(param.type)"
           }
           try VariableDeclSyntax("let _argsDecoder = JSONDecoder()")
 
           // do-catch statement JSON decoding the values in argv
           for (i, param) in parameters.enumerated() {
-            let paramName = (param.secondName ?? param.firstName).text.trimmingCharacters(in: .whitespacesAndNewlines)
             DoStmtSyntax(body: CodeBlockSyntax {
-              "\(raw: paramName) = try _argsDecoder.decode(\(param.type).self, from: cmdlineArgs[\(raw: i)])"
+              "\(raw: param.secondName?.text ?? param.firstName.text) = try _argsDecoder.decode(\(param.type).self, from: cmdlineArgs[\(raw: i)])"
             }, catchClauses: CatchClauseListSyntax {
               CatchClauseSyntax {
-                #"let _argError = _Ray.DecodingArgumentError(name: "\#(raw: paramName)", position: \#(raw: i), type: \#(param.type).self, data: cmdlineArgs[\#(raw: i)], underlying: error)"#
+                #"let _argError = _Ray.DecodingArgumentError(name: "\#(raw: param.secondName?.text ?? param.firstName.text)", position: \#(raw: i), type: \#(param.type).self, data: cmdlineArgs[\#(raw: i)], underlying: error)"#
                 "return callback.forward(error: _argError)"
               }
             })
@@ -67,9 +65,9 @@ public struct RaycastMacro: PeerMacro {
             for param in parameters {
               let isWildCard = param.firstName.tokenKind == .wildcard
               LabeledExprSyntax(
-                label: isWildCard ? .none : .init(stringLiteral: param.firstName.text.trimmingCharacters(in: .whitespacesAndNewlines)),
+                label: isWildCard ? .none : "\(raw: param.firstName.text)",
                 colon: isWildCard ? .none : .colonToken(),
-                expression: DeclReferenceExprSyntax(baseName: .identifier((param.secondName ?? param.firstName).text.trimmingCharacters(in: .whitespacesAndNewlines)))
+                expression: DeclReferenceExprSyntax(baseName: .identifier((param.secondName ?? param.firstName).text))
               )
             }
           }

--- a/SwiftMacros/Implementation/RaycastMacro.swift
+++ b/SwiftMacros/Implementation/RaycastMacro.swift
@@ -35,17 +35,19 @@ public struct RaycastMacro: PeerMacro {
 
           // Declare all the local variables holding the values decoded from the Command-line arguments
           for param in parameters {
-            "let \(param.secondName ?? param.firstName): \(param.type)"
+            let paramName = (param.secondName ?? param.firstName).text.trimmingCharacters(in: .whitespacesAndNewlines)
+            "let \(raw: paramName): \(param.type)"
           }
           try VariableDeclSyntax("let _argsDecoder = JSONDecoder()")
 
           // do-catch statement JSON decoding the values in argv
           for (i, param) in parameters.enumerated() {
+            let paramName = (param.secondName ?? param.firstName).text.trimmingCharacters(in: .whitespacesAndNewlines)
             DoStmtSyntax(body: CodeBlockSyntax {
-              "\(param.secondName ?? param.firstName) = try _argsDecoder.decode(\(param.type).self, from: cmdlineArgs[\(raw: i)])"
+              "\(raw: paramName) = try _argsDecoder.decode(\(param.type).self, from: cmdlineArgs[\(raw: i)])"
             }, catchClauses: CatchClauseListSyntax {
               CatchClauseSyntax {
-                #"let _argError = _Ray.DecodingArgumentError(name: "\#(raw: param.secondName ?? param.firstName)", position: \#(raw: i), type: \#(param.type).self, data: cmdlineArgs[\#(raw: i)], underlying: error)"#
+                #"let _argError = _Ray.DecodingArgumentError(name: "\#(raw: paramName)", position: \#(raw: i), type: \#(param.type).self, data: cmdlineArgs[\#(raw: i)], underlying: error)"#
                 "return callback.forward(error: _argError)"
               }
             })
@@ -65,9 +67,9 @@ public struct RaycastMacro: PeerMacro {
             for param in parameters {
               let isWildCard = param.firstName.tokenKind == .wildcard
               LabeledExprSyntax(
-                label: isWildCard ? .none : param.firstName,
+                label: isWildCard ? .none : .init(stringLiteral: param.firstName.text.trimmingCharacters(in: .whitespacesAndNewlines)),
                 colon: isWildCard ? .none : .colonToken(),
-                expression: DeclReferenceExprSyntax(baseName: .identifier((param.secondName ?? param.firstName).text))
+                expression: DeclReferenceExprSyntax(baseName: .identifier((param.secondName ?? param.firstName).text.trimmingCharacters(in: .whitespacesAndNewlines)))
               )
             }
           }


### PR DESCRIPTION
This PR addresses a bug where a multiline parameter function causes a compile error.

<img width="857" alt="extensions-swift" src="https://github.com/raycast/extensions-swift-tools/assets/11733014/44230797-793a-43a0-b049-aa50b06e31ae">

It seems like that SwiftSyntax extracts the leading line break into the name of the variable, which is then inserted into the generated macro, causing the compile error 🤔

The PR adds a simple ﻿`.trimmingCharacters(in: .whitespacesAndNewlines)` to any usage of the parameter/variable names since I didn't found a native SwiftSyntax solution for this problem 😅