### PR TITLE
fix: support macOS Tahoe 26 beta with updated Swift tools

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.2
 import PackageDescription
 import CompilerPluginSupport
 
 let package = Package(
   name: "extensions-swift-tools",
   platforms: [
-    .macOS(.v12)
+    .macOS(.v15)
   ],
   products: [
     .library(
@@ -22,7 +22,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.1.1"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "602.0.0-prerelease-2025-05-29"),
   ],
   targets: [
 
@@ -98,7 +98,7 @@ let package = Package(
       // swiftSettings: .swiftSettings
     )
   ],
-  swiftLanguageVersions: [.v5]
+  swiftLanguageModes: [.v6]
 )
 
 // private extension Array<SwiftSetting> {

--- a/TypeScriptPlugin/Implementation/ExportableFunction.swift
+++ b/TypeScriptPlugin/Implementation/ExportableFunction.swift
@@ -80,11 +80,11 @@ private extension ExportableFunction {
 
     if let args = type.genericArgumentClause?.arguments {
       switch name {
-      case "Set" where args.count == 1: return "Set<\(typeScriptType(for: args.first!.argument))>"
-      case "Array" where args.count == 1: return "\(typeScriptType(for: args.first!.argument))[]"
+      case "Set" where args.count == 1: return "Set<\\(typeScriptType(for: args.first!.argument.type))>"
+      case "Array" where args.count == 1: return "\\(typeScriptType(for: args.first!.argument))[]"
       case "Dictionary" where args.count == 2:
         let s = args.startIndex, e = args.index(after: s)
-        return "{ [key: \(typeScriptType(for: args[s].argument))]: \(typeScriptType(for: args[e].argument)) }"
+          return "{ [key: \\(typeScriptType(for: args[s].argument.type))]: \\(typeScriptType(for: args[e].argument.type)) }"
       default: return "any"
       }
     } else {


### PR DESCRIPTION
-   Update swift-tools-version to 6.2 and macOS platform to v15 for compatibility with the new macOS Tahoe 26 beta
-   Upgrade swift-syntax dependency to prerelease 602.0.0
-   Refine TypeScriptPlugin type handling for generics to ensure correct behavior on latest platform