### PR TITLE
fix: update package version to 1.0.5 in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To use Swift within Raycast:
     +      .macOS(.v12)
     +    ],
     +    dependencies: [
-    +      .package(url: "https://github.com/raycast/extensions-swift-tools", from: "1.0.4")
+    +      .package(url: "https://github.com/raycast/extensions-swift-tools", from: "1.0.5")
     +    ],
         targets: [
           .executableTarget(


### PR DESCRIPTION
## Summary
The README's `Package.swift` example references version `1.0.4` of this package, but `1.0.5` has been the latest release since January 2025. Version 1.0.5 is titled "Fix problems with spaces", so users following the README will install a version with a known bug rather than the fix.

## How to reproduce
1. Open README.md and find step 3 — "Modify the Package.swift file"
2. The `from:` version in the dependency example is `"1.0.4"`
3. Check the releases page — `1.0.5` was released on 2025-01-15 and is the latest

## Test plan
- Confirm the README example now shows `from: "1.0.5"`
- Verify `1.0.5` is the current latest release on https://github.com/raycast/extensions-swift-tools/releases