### PR TITLE
chore: swift-syntax 603 and Swift 6 toolchain support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 import CompilerPluginSupport
 
@@ -22,7 +22,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.1.1"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.0"),
   ],
   targets: [
 
@@ -40,7 +40,7 @@ let package = Package(
     .testTarget(
       name: "RaycastSwiftMacrosTests",
       dependencies: [
-        .target(name: "RaycastSwiftMacros"),
+        .target(name: "MacrosImplementation"),
         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
       ],
       path: "SwiftMacros/Tests"
@@ -97,8 +97,7 @@ let package = Package(
       path: "TypeScriptPlugin/Implementation"
       // swiftSettings: .swiftSettings
     )
-  ],
-  swiftLanguageVersions: [.v5]
+  ]
 )
 
 // private extension Array<SwiftSetting> {

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This Swift Package contains code generation macros and plugins to build a commun
 
 ### Requirements
 
-- Xcode.
+- Xcode 16.3 or later.
 
-  Xcode needs to be installed in your system. We are hoping to stop requiring Xcode in the future and just require the existence of a [Swift toolchain](https://www.swift.org/download/), alas we are not there yet. Please notice, you don't need to write the swift code in Xcode, you can use any other editor such as VSCode, Sublime, or Nova.
+  Xcode needs to be installed in your system (version 16.3 or later, since the package requires the Swift 6 toolchain and depends on [swift-syntax](https://github.com/swiftlang/swift-syntax) 603). We are hoping to stop requiring Xcode in the future and just require the existence of a [Swift toolchain](https://www.swift.org/download/), alas we are not there yet. Please notice, you don't need to write the swift code in Xcode, you can use any other editor such as VSCode, Sublime, or Nova.
 
 
 ## Using the Package
@@ -71,7 +71,7 @@ To use Swift within Raycast:
     +      .macOS(.v12)
     +    ],
     +    dependencies: [
-    +      .package(url: "https://github.com/raycast/extensions-swift-tools", from: "1.0.5")
+    +      .package(url: "https://github.com/raycast/extensions-swift-tools", from: "1.1.0")
     +    ],
         targets: [
           .executableTarget(

--- a/SwiftMacros/Implementation/RaycastMacro.swift
+++ b/SwiftMacros/Implementation/RaycastMacro.swift
@@ -53,7 +53,7 @@ public struct RaycastMacro: PeerMacro {
         }
 
         let isAsync = signature.effectSpecifiers?.asyncSpecifier != nil
-        let isThrow = signature.effectSpecifiers?.throwsSpecifier != nil
+        let isThrow = signature.effectSpecifiers?.throwsClause?.throwsSpecifier != nil
         let isReturning = Self.isReturning(clause: signature.returnClause)
 
         // Expression calling the actual targeted Swift function

--- a/SwiftPlugin/Interface/Interface.swift
+++ b/SwiftPlugin/Interface/Interface.swift
@@ -17,23 +17,23 @@ import PackagePlugin
     }
     // Verify the executable target doesn't contain a `main.swift` file.
     let unsupportedFile = "main.swift"
-    guard !target.sourceFiles.contains(where: { $0.type == .source && $0.path.lastComponent.lowercased() == unsupportedFile }) else {
+    guard !target.sourceFiles.contains(where: { $0.type == .source && $0.url.lastPathComponent.lowercased() == unsupportedFile }) else {
       Diagnostics.error("\(target.name) executable target cannot define a \(unsupportedFile) file")
       return []
     }
     // Retrieve the tool used to generate the Swift files.
-    let generator = try context.tool(named: "SwiftCodeGenerator").path
+    let generator = try context.tool(named: "SwiftCodeGenerator").url
     // Specify the path to the Swift file containing the @main structure (in the build folder)
     let generatedEntryType = "_RayMain"
     let generatedFile = "\(generatedEntryType).swift"
-    let generatedPath = context.pluginWorkDirectory.appending(subpath: generatedFile)
+    let generatedURL = context.pluginWorkDirectoryURL.appendingPathComponent(generatedFile)
     // Launch the Swift code generator for the target executing the build plugin.
     return [
       .buildCommand(
         displayName: "Generating \(generatedFile)",
         executable: generator,
-        arguments: ["-o", generatedPath.string, "-m", target.moduleName, "-t", generatedEntryType],
-        outputFiles: [generatedPath]
+        arguments: ["-o", generatedURL.path, "-m", target.moduleName, "-t", generatedEntryType],
+        outputFiles: [generatedURL]
       )
     ]
   }

--- a/TypeScriptPlugin/Implementation/ExportableFunction.swift
+++ b/TypeScriptPlugin/Implementation/ExportableFunction.swift
@@ -60,6 +60,13 @@ private extension ExportableFunction {
     return true
   }
 
+  // swift-syntax 600+ models a generic argument as a `.type`/`.expr` choice instead of a bare `TypeSyntax`.
+  // Generic arguments for Set/Array/Dictionary are always types, so unwrap the type (falling back to `any`).
+  static func typeScriptType(for argument: GenericArgumentSyntax.Argument) -> String {
+    guard let swiftType = argument.as(TypeSyntax.self) else { return "any" }
+    return typeScriptType(for: swiftType)
+  }
+
   static func typeScriptType(for swiftType: TypeSyntax) -> String {
     if let type = swiftType.as(OptionalTypeSyntax.self) {
       return "\(typeScriptType(for: type.wrappedType)) | null"

--- a/TypeScriptPlugin/Implementation/SyntaxParser.swift
+++ b/TypeScriptPlugin/Implementation/SyntaxParser.swift
@@ -45,7 +45,7 @@ private final class GlobalAttributedFunctionVisitor: SyntaxVisitor {
         attribute: id.name.text,
         name: node.name.text,
         isAsync: specifiers.flatMap(\.asyncSpecifier) != nil,
-        isThrowing: specifiers.flatMap(\.throwsSpecifier) != nil
+        isThrowing: specifiers.flatMap(\.throwsClause?.throwsSpecifier) != nil
       )
 
       for param in signature.parameterClause.parameters {

--- a/TypeScriptPlugin/Interface/Interface.swift
+++ b/TypeScriptPlugin/Interface/Interface.swift
@@ -17,34 +17,34 @@ import Foundation
       return []
     }
     // Retrieve the tool used to generate the TS definition and implementation.
-    let generator = try context.tool(named: "TypeScriptCodeGenerator").path
+    let generator = try context.tool(named: "TypeScriptCodeGenerator").url
     // Define the attributes used to mark functions as _exportable_
     let attributes: [String] = ["@raycast"]
 
-    var paths: Set<Path> = []
+    var fileURLs: Set<URL> = []
     // Enumerate all Swift files in the target.
     for file in target.sourceFiles(withSuffix: "swift") {
       // Select those files containing any of the specified exportable attributes.
-      guard case .source = file.type, !paths.contains(file.path),
+      guard case .source = file.type, !fileURLs.contains(file.url),
             try await file.contains(attributes: attributes) else { continue }
-      paths.insert(file.path)
+      fileURLs.insert(file.url)
     }
 
-    guard !paths.isEmpty else {
+    guard !fileURLs.isEmpty else {
       Diagnostics.warning("Target '\(target.name) had no file with exported attributes: \(attributes.joined(separator: " or "))")
       return []
     }
 
     // Generate the header and implementation file names.
-    let headerPath = context.pluginWorkDirectory.appending(subpath: "raycast.d.ts")
-    let implementationPath = context.pluginWorkDirectory.appending(subpath: "raycast.js")
+    let headerURL = context.pluginWorkDirectoryURL.appendingPathComponent("raycast.d.ts")
+    let implementationURL = context.pluginWorkDirectoryURL.appendingPathComponent("raycast.js")
 
     return [
       .buildCommand(
         displayName: "Generating d.ts and js files",
         executable: generator,
-        arguments: ["-h", headerPath.string, "-i", implementationPath.string, "-a"] + attributes + ["-f"] + paths.map(\.string),
-        outputFiles: [headerPath, implementationPath]
+        arguments: ["-h", headerURL.path, "-i", implementationURL.path, "-a"] + attributes + ["-f"] + fileURLs.map(\.path),
+        outputFiles: [headerURL, implementationURL]
       )
     ]
   }

--- a/TypeScriptPlugin/Interface/PackagePluginFile.swift
+++ b/TypeScriptPlugin/Interface/PackagePluginFile.swift
@@ -7,21 +7,11 @@ extension PackagePlugin.File {
   /// Look for the existence of any of the given `attributes` in the receiving file.
   /// - note: This is a _lazy_ function, meaning that as soon as an attribute existence is identified, no more lines in the receiving file will get read.
   func contains(attributes: [String]) async throws -> Bool {
-    for try await line in path.url.lines {
+    for try await line in url.lines {
       for attribute in attributes where line.contains(attribute) {
         return true
       }
     }
     return false
-  }
-}
-
-extension PackagePlugin.Path {
-  var url: URL {
-    if #available(macOS 13, *) {
-      URL(filePath: string)
-    } else {
-      URL(fileURLWithPath: string)
-    }
   }
 }


### PR DESCRIPTION
Bump swift-syntax to 603.0.0 (swiftlang fork) and adapt to breaking API changes:

- Read `throwsSpecifier` via `throwsClause` (now nested)
- Handle `GenericArgumentSyntax.Argument` enum for Set/Array/Dictionary element types
- Point macro test target at `MacrosImplementation`

Move the package fully to Swift 6:

- `swift-tools-version` bumped to 6.0 — older toolchains fail dependency resolution with a clear error
- The `swiftLanguageVersions: [.v5]` pin is gone; every target builds in the default Swift 6 language mode (verified `-swift-version 6`, clean build, no concurrency issues)
- Build plugins migrated off the deprecated `Path` API to the URL-based `PackagePlugin` API, since with tools 6.x those deprecation warnings would show up in every consumer's build. Generator arguments still receive plain (non percent-encoded) filesystem paths, so the spaces-in-paths fix is preserved

Docs:

- README requirements now state Xcode 16.3 or later (Swift 6 toolchain, swift-syntax 603's tested macOS floor) and the `Package.swift` example points at the upcoming 1.1.0 release

Verified with Xcode 26.4 (Swift 6.3): from-scratch build with zero warnings, 17/17 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)